### PR TITLE
Make dispose check for null instead of already disposed.

### DIFF
--- a/ImageMagickSharp.Tests/BaseTest.cs
+++ b/ImageMagickSharp.Tests/BaseTest.cs
@@ -122,6 +122,13 @@ namespace ImageMagickSharp.Tests
         public void TestCleanup()
         {
             //WandInitializer.DisposeEnvironment();
+
+            // Ensure finalizers run to catch some memory errors early
+            GC.Collect(2);
+            GC.Collect(2);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(2);
+            GC.Collect(2);
         }
 
         [TestInitialize]

--- a/ImageMagickSharp/Drawing/DrawingWand.cs
+++ b/ImageMagickSharp/Drawing/DrawingWand.cs
@@ -447,9 +447,6 @@ namespace ImageMagickSharp
 		#endregion
 
 		#region [IDisposable]
-		/// <summary> true if disposed. </summary>
-		private bool disposed = false;
-
 		/// <summary> Finalizes an instance of the ImageMagickSharp.DrawingWand class. </summary>
 		~DrawingWand()
 		{
@@ -473,12 +470,10 @@ namespace ImageMagickSharp
 		/// release only unmanaged resources. </param>
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!this.disposed)
+            if (this.Handle != IntPtr.Zero)
 			{
 				DrawingWandInterop.DestroyDrawingWand(this);
 				this.Handle = IntPtr.Zero;
-				disposed = true;
-
 			}
 		}
 

--- a/ImageMagickSharp/Magick/MagickWand.cs
+++ b/ImageMagickSharp/Magick/MagickWand.cs
@@ -544,9 +544,6 @@ namespace ImageMagickSharp
 			this.Dispose(false);
 		}
 
-		/// <summary> true if disposed. </summary>
-		private bool disposed = false;
-
 		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged
 		/// resources. </summary>
@@ -564,12 +561,10 @@ namespace ImageMagickSharp
 		/// release only unmanaged resources. </param>
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!this.disposed)
+            if (this.Handle != IntPtr.Zero)
 			{
 				this.Handle = MagickWandInterop.DestroyMagickWand(this);
 				this.Handle = IntPtr.Zero;
-				disposed = true;
-
 			}
 		}
 

--- a/ImageMagickSharp/MagickCore/MagickCore.cs
+++ b/ImageMagickSharp/MagickCore/MagickCore.cs
@@ -84,9 +84,6 @@ namespace ImageMagickSharp
             this.Dispose(false);
         }
 
-        /// <summary> true if disposed. </summary>
-        private bool disposed = false;
-
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged
         /// resources. </summary>
@@ -104,12 +101,10 @@ namespace ImageMagickSharp
         /// release only unmanaged resources. </param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.disposed)
+            if (this.Handle != IntPtr.Zero)
             {
-                //this.Handle = MagickWandInterop.DestroyMagickWand(this);
-                this.Handle = IntPtr.Zero;
-                disposed = true;
-
+                this.Handle = MagickWandInterop.DestroyMagickWand(this);
+                this.Handle = IntPtr.Zero;                
             }
         }
 

--- a/ImageMagickSharp/Pixel/PixelIterator.cs
+++ b/ImageMagickSharp/Pixel/PixelIterator.cs
@@ -218,10 +218,6 @@ namespace ImageMagickSharp
 
         #region [IDisposable]
 
-
-        /// <summary> true if disposed. </summary>
-        private bool disposed = false;
-
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged
         /// resources. </summary>
@@ -239,11 +235,10 @@ namespace ImageMagickSharp
         /// release only unmanaged resources. </param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.disposed)
+            if (this.Handle != IntPtr.Zero)
             {
                 PixelIteratorInterop.DestroyPixelIterator(this);
-                this.Handle = IntPtr.Zero;
-                disposed = true;
+                this.Handle = IntPtr.Zero;                
             }
         }
         #endregion

--- a/ImageMagickSharp/Pixel/PixelWand.cs
+++ b/ImageMagickSharp/Pixel/PixelWand.cs
@@ -212,10 +212,6 @@ namespace ImageMagickSharp
 		#endregion
 
 		#region [IDisposable]
-
-		/// <summary> true if disposed. </summary>
-		private bool disposed = false;
-
 		/// <summary> Finalizes an instance of the ImageMagickSharp.MagickWand class. </summary>
 		~PixelWand()
 		{
@@ -239,11 +235,10 @@ namespace ImageMagickSharp
 		/// release only unmanaged resources. </param>
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!this.disposed)
+            if (this.Handle != IntPtr.Zero)
 			{
 				PixelWandInterop.DestroyPixelWand(this);
-				this.Handle = IntPtr.Zero;
-				disposed = true;
+				this.Handle = IntPtr.Zero;				
 
 			}
 		}


### PR DESCRIPTION
 Passing null into the destroy methods causes access violations.