### PR TITLE
Remote the implicit conversion below from string to 

### DIFF
--- a/ImageMagickSharp.Tests/Extensions/CoverArtWandTests.cs
+++ b/ImageMagickSharp.Tests/Extensions/CoverArtWandTests.cs
@@ -49,8 +49,9 @@ namespace ImageMagickSharp.Tests
 			using (var wand = new MagickWand(TestImageFolder1))
 			{
 				using (MagickWand nailclone = wand.CloneMagickWand())
+                using (var blackPixelWand = new PixelWand(ColorName.Black))
 				{
-					nailclone.CurrentImage.BackgroundColor = ColorName.Black;
+                    nailclone.CurrentImage.BackgroundColor = blackPixelWand;
 					nailclone.CurrentImage.ShadowImage(80, 5, 5, 5);
 					nailclone.CurrentImage.CompositeImage(wand, CompositeOperator.CopyCompositeOp, 0, 0);
 					nailclone.SaveImage(Path.Combine(SaveDirectory, "logo_extent.png"));

--- a/ImageMagickSharp.Tests/Extensions/MediaBrowserWandTests.cs
+++ b/ImageMagickSharp.Tests/Extensions/MediaBrowserWandTests.cs
@@ -72,15 +72,18 @@ namespace ImageMagickSharp.Tests
 		public void MediaBrowserWandTextTests()
 		{
 			using (var wand = new MagickWand(TestImageBackdrop))
+            using (var yellowPixelWand = new PixelWand("yellow"))            
+            using (var whitePixelWand = new PixelWand("white"))
+            using (var blackPixelWand = new PixelWand("black", 0.5))
 			{
 
-				wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, "yellow", new PixelWand("black", 0.5));
+                wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, yellowPixelWand, blackPixelWand);
 
-				wand.CurrentImage.DrawCircle(400, 300, 500, 400, "yellow", new PixelWand("black", 0.5));
-				wand.CurrentImage.DrawCircle(400, 400, 60, "yellow", new PixelWand("black", 0.5));
+                wand.CurrentImage.DrawCircle(400, 300, 500, 400, yellowPixelWand, blackPixelWand);
+                wand.CurrentImage.DrawCircle(400, 400, 60, yellowPixelWand, blackPixelWand);
 
-				wand.CurrentImage.DrawRectangle(0, wand.CurrentImage.Height - 70, wand.CurrentImage.Width - 1, wand.CurrentImage.Height, "yellow", new PixelWand("black", 0.5));
-				wand.CurrentImage.DrawText("Media Browser", 10, wand.CurrentImage.Height - 10, "Arial", 60, "white", FontWeightType.BoldStyle);
+                wand.CurrentImage.DrawRectangle(0, wand.CurrentImage.Height - 70, wand.CurrentImage.Width - 1, wand.CurrentImage.Height, yellowPixelWand, blackPixelWand);
+                wand.CurrentImage.DrawText("Media Browser", 10, wand.CurrentImage.Height - 10, "Arial", 60, whitePixelWand, FontWeightType.BoldStyle);
 
 				wand.SaveImage(Path.Combine(SaveDirectory, "TestImageBackdrop.jpg"));
 			}

--- a/ImageMagickSharp.Tests/Image/ImageWandTests.cs
+++ b/ImageMagickSharp.Tests/Image/ImageWandTests.cs
@@ -143,13 +143,15 @@ namespace ImageMagickSharp.Tests
 		{
 
 			using (var wand = new MagickWand())
+            using (var yellowPixelWand = new PixelWand("yellow"))
+            using (var blackPixelWand = new PixelWand("black", 0.5))
 			{
 				wand.NewImage(200, 200, "Blue");
-				wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, "yellow", new PixelWand("black", 0.5));
+                wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, yellowPixelWand, blackPixelWand);
 				wand.NewImage(200, 200, "red");
-				wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, "yellow", new PixelWand("black", 0.5));
+                wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, yellowPixelWand, blackPixelWand);
 				wand.NewImage(200, 200, "green");
-				wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, "yellow", new PixelWand("black", 0.5));
+                wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, yellowPixelWand, blackPixelWand);
 				wand.SaveImages(Path.Combine(SaveDirectory, "logo_extent.jpg"));
 
 			}
@@ -160,9 +162,11 @@ namespace ImageMagickSharp.Tests
 		{
 
 			using (var wand = new MagickWand())
+            using (var yellowPixelWand = new PixelWand("yellow"))
+            using (var blackPixelWand = new PixelWand("black", 0.5))
 			{
 				wand.NewImage(200, 200, "Blue");
-				wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, "yellow", new PixelWand("black", 0.5));
+                wand.CurrentImage.DrawRoundRectangle(10, 10, wand.CurrentImage.Width - 10, 70, 5, 5, yellowPixelWand, blackPixelWand);
 				var t = wand.GetImage();
 				//wand.Image.RotateImage("red", 45);
 				//t.RotateImage("red", 45);
@@ -177,8 +181,9 @@ namespace ImageMagickSharp.Tests
 		public void ImageWandLabelImageTests()
 		{
 			using (var wand = new MagickWand(200, 200, "lightblue"))
+            using (var maroonPixelWand = new PixelWand(ColorName.Maroon))
 			{
-				wand.BackgroundColor = ColorName.Maroon;
+				wand.BackgroundColor = maroonPixelWand;
 
 				wand.Font = "Arial";
 				Debug.Print(wand.Font);
@@ -190,18 +195,18 @@ namespace ImageMagickSharp.Tests
 		}
 
 		[TestMethod()]
-		public void GetImagePixelColorTest()
-		{
-			var path = TestImageFolder1;
+        public void GetImagePixelColorTest()
+        {
+            var path = TestImageFolder1;
 
-			Assert.IsTrue(File.Exists(path));
+            Assert.IsTrue(File.Exists(path));
 
-			using (var wand = new MagickWand(path))
-			{
-				var pi = wand.CurrentImage.GetImagePixelColor(1, 1);
-				Debug.Print(pi.Color);
-			}
-		}
+            using (var wand = new MagickWand(path))
+            {
+                var pi = wand.CurrentImage.GetImagePixelColor(1, 1);
+                Debug.Print(pi.Color);
+            }
+        }
 
 		//Todo
 		[TestMethod()]

--- a/ImageMagickSharp/Extensions/CoverArtWandExtension.cs
+++ b/ImageMagickSharp/Extensions/CoverArtWandExtension.cs
@@ -21,14 +21,17 @@ namespace ImageMagickSharp.Extensions
 			{
 				double x = 0;
 				double y = 0;
-				using (var wandimages = new MagickWand(images))
+				using (var wandimages = new MagickWand(images))                
 				{
 					foreach (ImageWand imageWand in wandimages.ImageList)
 					{
-						imageWand.BorderImage("black", 2, 2);
-						draw.DrawComposite(CompositeOperator.AtopCompositeOp, x, y, width, height, imageWand);
-						x += xIncrement;
-						y += yIncrement;
+					    using (var blackPixelWand = new PixelWand("black"))
+					    {
+                            imageWand.BorderImage(blackPixelWand, 2, 2);
+                            draw.DrawComposite(CompositeOperator.AtopCompositeOp, x, y, width, height, imageWand);
+                            x += xIncrement;
+                            y += yIncrement;    
+					    }						
 					}
 				}
 				wand.CurrentImage.DrawImage(draw);

--- a/ImageMagickSharp/Extensions/MediaBrowserWandExtension.cs
+++ b/ImageMagickSharp/Extensions/MediaBrowserWandExtension.cs
@@ -139,7 +139,9 @@ namespace ImageMagickSharp.Extensions
             var currentHeight = wand.CurrentImage.Height;
 
             var newWand = new MagickWand(currentWidth, currentHeight, new PixelWand(ColorName.None, 1));
-            using (var draw = new DrawingWand(ColorName.White))
+            
+            using (var whitePixelWand = new PixelWand(ColorName.White))
+            using (var draw = new DrawingWand(whitePixelWand))
             {
                 draw.DrawRoundRectangle(0, 0, currentWidth, currentHeight, cofactor, cofactor);
                 newWand.CurrentImage.DrawImage(draw);
@@ -169,14 +171,18 @@ namespace ImageMagickSharp.Extensions
 
                 foreach (var element in wandImages.ImageList)
                 {
-                    int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
-                    element.Gravity = GravityType.CenterGravity;
-                    element.BackgroundColor = ColorName.Black;
-                    element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
-                    int ix = (int)Math.Abs((iWidth - iSlice) / 2);
-                    element.CropImage(iSlice, iHeight, ix, 0);
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    {
+                        int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
+                        element.Gravity = GravityType.CenterGravity;
+                        element.BackgroundColor = blackPixelWand;
+                        element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
+                        int ix = (int)Math.Abs((iWidth - iSlice) / 2);
+                        element.CropImage(iSlice, iHeight, ix, 0);
 
-                    element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);
+                        element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);    
+                    }
+                    
                 }
 
                 wandImages.SetFirstIterator();
@@ -184,12 +190,14 @@ namespace ImageMagickSharp.Extensions
                 {
                     wandList.CurrentImage.TrimImage(1);
                     using (var mwr = wandList.CloneMagickWand())
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    using (var greyPixelWand = new PixelWand(ColorName.Grey70))
                     {
                         mwr.CurrentImage.ResizeImage(wandList.CurrentImage.Width, (wandList.CurrentImage.Height / 2), FilterTypes.LanczosFilter, 1);
                         mwr.CurrentImage.FlipImage();
 
                         mwr.CurrentImage.AlphaChannel = AlphaChannelType.DeactivateAlphaChannel;
-                        mwr.CurrentImage.ColorizeImage(ColorName.Black, ColorName.Grey70);
+                        mwr.CurrentImage.ColorizeImage(blackPixelWand, greyPixelWand);
 
                         using (var mwg = new MagickWand(wandList.CurrentImage.Width, iTrans))
                         {
@@ -225,18 +233,23 @@ namespace ImageMagickSharp.Extensions
 
                 foreach (var element in wandImages.ImageList)
                 {
-                    int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
-                    element.Gravity = GravityType.CenterGravity;
-                    element.BackgroundColor = ColorName.Black;
-                    element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
-                    int ix = (int)Math.Abs((iWidth - iSlice) / 2);
-                    element.CropImage(iSlice, iHeight, ix, 0);
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    {
+                        int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
+                        element.Gravity = GravityType.CenterGravity;
+                        element.BackgroundColor = blackPixelWand;
+                        element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
+                        int ix = (int)Math.Abs((iWidth - iSlice) / 2);
+                        element.CropImage(iSlice, iHeight, ix, 0);
 
-                    element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);
+                        element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);    
+                    }                    
                 }
 
                 wandImages.SetFirstIterator();
                 using (var wandList = wandImages.AppendImages())
+                using (var blackPixelWand = new PixelWand(ColorName.Black))
+                using (var greyPixelWand = new PixelWand(ColorName.Grey70))
                 {
                     wandList.CurrentImage.TrimImage(1);
                     using (var mwr = wandList.CloneMagickWand())
@@ -245,7 +258,7 @@ namespace ImageMagickSharp.Extensions
                         mwr.CurrentImage.FlipImage();
 
                         mwr.CurrentImage.AlphaChannel = AlphaChannelType.DeactivateAlphaChannel;
-                        mwr.CurrentImage.ColorizeImage(ColorName.Black, ColorName.Grey70);
+                        mwr.CurrentImage.ColorizeImage(blackPixelWand, greyPixelWand);
 
                         using (var mwg = new MagickWand(wandList.CurrentImage.Width, iTrans))
                         {
@@ -294,14 +307,17 @@ namespace ImageMagickSharp.Extensions
 
                 foreach (var element in wandImages.ImageList)
                 {
-                    int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
-                    element.Gravity = GravityType.CenterGravity;
-                    element.BackgroundColor = new PixelWand("none", 1);
-                    element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
-                    int ix = (int)Math.Abs((iWidth - iSlice) / 2);
-                    element.CropImage(iSlice, iHeight, ix, 0);
+                    using (var nonePixelWand = new PixelWand("none", 1))
+                    {
+                        int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
+                        element.Gravity = GravityType.CenterGravity;
+                        element.BackgroundColor = nonePixelWand;
+                        element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
+                        int ix = (int)Math.Abs((iWidth - iSlice) / 2);
+                        element.CropImage(iSlice, iHeight, ix, 0);
 
-                    element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);
+                        element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);    
+                    }                    
                 }
 
                 wandImages.SetFirstIterator();
@@ -309,12 +325,14 @@ namespace ImageMagickSharp.Extensions
                 {
                     wandList.CurrentImage.TrimImage(1);
                     using (var mwr = wandList.CloneMagickWand())
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    using (var greyPixelWand = new PixelWand(ColorName.Grey60))
                     {
                         mwr.CurrentImage.ResizeImage(wandList.CurrentImage.Width, (wandList.CurrentImage.Height / 2), FilterTypes.LanczosFilter, 1);
                         mwr.CurrentImage.FlipImage();
 
                         mwr.CurrentImage.AlphaChannel = AlphaChannelType.DeactivateAlphaChannel;
-                        mwr.CurrentImage.ColorizeImage(ColorName.Black, ColorName.Grey60);
+                        mwr.CurrentImage.ColorizeImage(blackPixelWand, greyPixelWand);
 
                         using (var mwg = new MagickWand(wandList.CurrentImage.Width, iTrans))
                         {
@@ -350,14 +368,17 @@ namespace ImageMagickSharp.Extensions
 
                 foreach (var element in wandImages.ImageList)
                 {
-                    int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
-                    element.Gravity = GravityType.CenterGravity;
-                    element.BackgroundColor = ColorName.Black;
-                    element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
-                    int ix = (int)Math.Abs((iWidth - iSlice) / 2);
-                    element.CropImage(iSlice, iHeight, ix, 0);
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    {
+                        int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
+                        element.Gravity = GravityType.CenterGravity;
+                        element.BackgroundColor = blackPixelWand;
+                        element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
+                        int ix = (int)Math.Abs((iWidth - iSlice) / 2);
+                        element.CropImage(iSlice, iHeight, ix, 0);
 
-                    element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);
+                        element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);    
+                    }                    
                 }
 
                 wandImages.SetFirstIterator();
@@ -365,12 +386,14 @@ namespace ImageMagickSharp.Extensions
                 {
                     wandList.CurrentImage.TrimImage(1);
                     using (var mwr = wandList.CloneMagickWand())
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    using (var greyPixelWand = new PixelWand(ColorName.Grey70))
                     {
                         mwr.CurrentImage.ResizeImage(wandList.CurrentImage.Width, (wandList.CurrentImage.Height / 2), FilterTypes.LanczosFilter, 1);
                         mwr.CurrentImage.FlipImage();
 
                         mwr.CurrentImage.AlphaChannel = AlphaChannelType.DeactivateAlphaChannel;
-                        mwr.CurrentImage.ColorizeImage(ColorName.Black, ColorName.Grey70);
+                        mwr.CurrentImage.ColorizeImage(blackPixelWand, greyPixelWand);
 
                         using (var mwg = new MagickWand(wandList.CurrentImage.Width, iTrans))
                         {
@@ -419,14 +442,17 @@ namespace ImageMagickSharp.Extensions
 
                 foreach (var element in wandImages.ImageList)
                 {
-                    int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
-                    element.Gravity = GravityType.CenterGravity;
-                    element.BackgroundColor = new PixelWand("none", 1);
-                    element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
-                    int ix = (int)Math.Abs((iWidth - iSlice) / 2);
-                    element.CropImage(iSlice, iHeight, ix, 0);
+                    using (var nonePixelWand = new PixelWand("none", 1))
+                    {
+                        int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
+                        element.Gravity = GravityType.CenterGravity;
+                        element.BackgroundColor = nonePixelWand;
+                        element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
+                        int ix = (int)Math.Abs((iWidth - iSlice) / 2);
+                        element.CropImage(iSlice, iHeight, ix, 0);
 
-                    element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);
+                        element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);    
+                    }                    
                 }
 
                 wandImages.SetFirstIterator();
@@ -434,12 +460,14 @@ namespace ImageMagickSharp.Extensions
                 {
                     wandList.CurrentImage.TrimImage(1);
                     using (var mwr = wandList.CloneMagickWand())
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    using (var greyPixelWand = new PixelWand(ColorName.Grey60))
                     {
                         mwr.CurrentImage.ResizeImage(wandList.CurrentImage.Width, (wandList.CurrentImage.Height / 2), FilterTypes.LanczosFilter, 1);
                         mwr.CurrentImage.FlipImage();
 
                         mwr.CurrentImage.AlphaChannel = AlphaChannelType.DeactivateAlphaChannel;
-                        mwr.CurrentImage.ColorizeImage(ColorName.Black, ColorName.Grey60);
+                        mwr.CurrentImage.ColorizeImage(blackPixelWand, greyPixelWand);
 
                         using (var mwg = new MagickWand(wandList.CurrentImage.Width, iTrans))
                         {
@@ -488,14 +516,17 @@ namespace ImageMagickSharp.Extensions
 
                 foreach (var element in wandImages.ImageList)
                 {
-                    int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
-                    element.Gravity = GravityType.CenterGravity;
-                    element.BackgroundColor = new PixelWand("none", 1);
-                    element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
-                    int ix = (int)Math.Abs((iWidth - iSlice) / 2);
-                    element.CropImage(iSlice, iHeight, ix, 0);
+                    using (var nonePixelWand = new PixelWand("none", 1))
+                    {
+                        int iWidth = (int)Math.Abs(iHeight * element.Width / element.Height);
+                        element.Gravity = GravityType.CenterGravity;
+                        element.BackgroundColor = nonePixelWand;
+                        element.ResizeImage(iWidth, iHeight, FilterTypes.LanczosFilter);
+                        int ix = (int)Math.Abs((iWidth - iSlice) / 2);
+                        element.CropImage(iSlice, iHeight, ix, 0);
 
-                    element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);
+                        element.ExtentImage(iSlice, iHeight, 0 - horizontalImagePadding, 0);    
+                    }                    
                 }
 
                 wandImages.SetFirstIterator();
@@ -503,12 +534,14 @@ namespace ImageMagickSharp.Extensions
                 {
                     wandList.CurrentImage.TrimImage(1);
                     using (var mwr = wandList.CloneMagickWand())
+                    using (var blackPixelWand = new PixelWand(ColorName.Black))
+                    using (var greyPixelWand = new PixelWand(ColorName.Grey60))
                     {
                         mwr.CurrentImage.ResizeImage(wandList.CurrentImage.Width, (wandList.CurrentImage.Height / 2), FilterTypes.LanczosFilter, 1);
                         mwr.CurrentImage.FlipImage();
 
                         mwr.CurrentImage.AlphaChannel = AlphaChannelType.DeactivateAlphaChannel;
-                        mwr.CurrentImage.ColorizeImage(ColorName.Black, ColorName.Grey60);
+                        mwr.CurrentImage.ColorizeImage(blackPixelWand, greyPixelWand);
 
                         using (var mwg = new MagickWand(wandList.CurrentImage.Width, iTrans))
                         {

--- a/ImageMagickSharp/Pixel/PixelWand.cs
+++ b/ImageMagickSharp/Pixel/PixelWand.cs
@@ -192,15 +192,7 @@ namespace ImageMagickSharp
 		#endregion
 
 		#region [Pixel Wand Operators]
-
-		/// <summary> Implicit cast that converts the given string to a PixelWand. </summary>
-		/// <param name="color"> The color. </param>
-		/// <returns> The result of the operation. </returns>
-		public static implicit operator PixelWand(string color)
-		{
-			return new PixelWand(color);
-		}
-
+		
 		/// <summary> Implicit cast that converts the given PixelWand to a string. </summary>
 		/// <param name="wand"> The wand. </param>
 		/// <returns> The result of the operation. </returns>


### PR DESCRIPTION
The implicit conversion below from string to PixelWand made it way too easy to leak memory. I've corrected all the places I have found a leak thus far.

THIS NEEDS TESTING!